### PR TITLE
fix: add durable_objects bindings to all wrangler environments

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -23,15 +23,33 @@
 	"env": {
 		"integration": {
 			"name": "golden-key-matrix-integration",
-			"vars": {}
+			"vars": {},
+			"durable_objects": {
+				"bindings": [
+					{ "name": "SESSION_DO", "class_name": "SessionDurableObject" },
+					{ "name": "SYNCED_STATE_DO", "class_name": "SyncedStateServer" }
+				]
+			}
 		},
 		"staging": {
 			"name": "golden-key-matrix-staging",
-			"vars": {}
+			"vars": {},
+			"durable_objects": {
+				"bindings": [
+					{ "name": "SESSION_DO", "class_name": "SessionDurableObject" },
+					{ "name": "SYNCED_STATE_DO", "class_name": "SyncedStateServer" }
+				]
+			}
 		},
 		"production": {
 			"name": "golden-key-matrix",
-			"vars": {}
+			"vars": {},
+			"durable_objects": {
+				"bindings": [
+					{ "name": "SESSION_DO", "class_name": "SessionDurableObject" },
+					{ "name": "SYNCED_STATE_DO", "class_name": "SyncedStateServer" }
+				]
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Wrangler does not inherit `durable_objects` from the top-level config into named environments
- Added explicit `durable_objects.bindings` to `integration`, `staging`, and `production` env blocks
- Fixes deploy error: _"durable_objects exists at the top level, but not on env.integration"_

## Test plan
- [ ] CI deploy job passes for `integration` environment without the durable_objects warning