### PR TITLE
fix: use new_sqlite_classes migration for free plan DO compatibility

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -18,7 +18,7 @@
 		]
 	},
 	"migrations": [
-		{ "tag": "v1", "new_classes": ["SessionDurableObject", "SyncedStateServer"] }
+		{ "tag": "v1", "new_sqlite_classes": ["SessionDurableObject", "SyncedStateServer"] }
 	],
 	"env": {
 		"integration": {


### PR DESCRIPTION
## Summary
- Cloudflare now requires `new_sqlite_classes` instead of `new_classes` for Durable Objects on the free plan
- Fixes deploy error: _"In order to use Durable Objects with a free plan, you must create a namespace using a new_sqlite_classes migration. [code: 10097]"_

## Test plan
- [ ] CI deploy job passes for `integration` environment