### PR TITLE
feat: add manual staging/production deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,75 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to deploy (e.g. v1.2.3)"
+        required: true
+        type: string
+
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy-staging:
+    name: Deploy to Staging
+    runs-on: ubuntu-latest
+    environment: staging
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Deploy to Staging
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_ENV: staging
+        run: pnpm release
+
+  deploy-production:
+    name: Deploy to Production
+    runs-on: ubuntu-latest
+    needs: deploy-staging
+    environment: production
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Deploy to Production
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_ENV: production
+        run: pnpm release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
   release:
     name: Release & Deploy to Integration
     runs-on: ubuntu-latest
+    environment: integration
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch` workflow (`deploy.yml`) triggered manually with a git tag input
- `deploy-staging` job checks out the tag and deploys to the `staging` CF environment
- `deploy-production` job has `needs: deploy-staging` — it cannot run unless staging succeeded in the same workflow run
- Both jobs use GitHub Environments, so you get deployment history and the `production` environment can be configured with required reviewers for an approval gate before prod deploys

## One-time GitHub setup required
Before this workflow is useful, create two Environments in **repo Settings → Environments**:
1. `staging` — no protection rules needed
2. `production` — add yourself (and Dorothy?) as a **required reviewer** — this creates the approval gate between staging success and production deploy

## Test plan
- [ ] Merge and run the workflow manually from Actions tab with a valid tag
- [ ] Confirm staging deploys, then production waits for approval
- [ ] Approve and confirm production deploys