### PR TITLE
refactor: separate release and deploy workflows, chain all three envs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,29 +1,53 @@
 name: Deploy
 
 on:
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "Git tag to deploy (e.g. v1.2.3)"
-        required: true
-        type: string
+  push:
+    tags:
+      - "v*"
 
 concurrency:
-  group: deploy
+  group: deploy-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
+  deploy-integration:
+    name: Deploy to Integration
+    runs-on: ubuntu-latest
+    environment: integration
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Deploy to Integration
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_ENV: integration
+        run: pnpm release
+
   deploy-staging:
     name: Deploy to Staging
     runs-on: ubuntu-latest
+    needs: deploy-integration
     environment: staging
     permissions:
       contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.tag }}
 
       - uses: pnpm/action-setup@v4
         with:
@@ -53,8 +77,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.tag }}
 
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release & Deploy
+name: Release
 
 on:
   push:
@@ -10,9 +10,8 @@ concurrency:
 
 jobs:
   release:
-    name: Release & Deploy to Integration
+    name: Semantic Release
     runs-on: ubuntu-latest
-    environment: integration
     permissions:
       contents: write
       issues: write
@@ -39,11 +38,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm semantic-release
-
-      - name: Deploy to Integration
-        if: success()
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_ENV: integration
-        run: pnpm release


### PR DESCRIPTION
## Summary
- `release.yml` now only runs semantic-release — no deploy step
- `deploy.yml` triggers on tag push (`v*`) and chains all three environments:
  - **Integration** deploys automatically
  - **Staging** requires integration to succeed + GitHub Environment approval
  - **Production** requires staging to succeed + GitHub Environment approval

## Full flow
merge to main → semantic-release creates tag → deploy workflow triggers → integration auto-deploys → staging waits for approval → production waits for approval

## Test plan
- [ ] Merge triggers release workflow, semantic-release creates a tag
- [ ] Tag creation triggers deploy workflow, integration deploys automatically
- [ ] Staging job shows as waiting for approval, deploys after approval
- [ ] Production job shows as waiting for approval, deploys after approval