### PR TITLE
feat: add /dev/qr-poll page with QR code and synced session tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"prepare": "husky"
 	},
 	"dependencies": {
+		"qrcode.react": "^4.2.0",
 		"radix-ui": "latest",
 		"react": "19.2.4",
 		"react-dom": "19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.4)
       radix-ui:
         specifier: latest
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -3933,6 +3936,11 @@ packages:
   puppeteer-core@24.38.0:
     resolution: {integrity: sha512-zB3S/tksIhgi2gZRndUe07AudBz5SXOB7hqG0kEa9/YXWrGwlVlYm3tZtwKgfRftBzbmLQl5iwHkQQl04n/mWw==}
     engines: {node: '>=18'}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   radix-ui@1.4.3:
     resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
@@ -8854,6 +8862,10 @@ snapshots:
       - react-native-b4a
       - supports-color
       - utf-8-validate
+
+  qrcode.react@4.2.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:

--- a/src/components/dev/QrPollClient.tsx
+++ b/src/components/dev/QrPollClient.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useSyncedState } from "rwsdk/use-synced-state/client";
+import { QRCodeSVG } from "qrcode.react";
+import { useEffect } from "react";
+
+type Props = {
+	sessionId: string | null;
+	pollUrl: string;
+};
+
+export const QrPollClient = ({ sessionId, pollUrl }: Props) => {
+	const [connectedSessions, setConnectedSessions] = useSyncedState<string[]>(
+		[],
+		"sessions",
+		"dev-qr-poll",
+	);
+
+	useEffect(() => {
+		if (!sessionId) return;
+		setConnectedSessions((prev) => {
+			if (prev.includes(sessionId)) return prev;
+			return [...prev, sessionId];
+		});
+	}, [sessionId, setConnectedSessions]);
+
+	return (
+		<div>
+			<h1>QR Poll Test</h1>
+
+			<h2>Scan to Join</h2>
+			<QRCodeSVG value={pollUrl} size={256} />
+			<p>
+				<a href={pollUrl}>{pollUrl}</a>
+			</p>
+
+			<h2>Your Session ID</h2>
+			<ul>
+				<li>{sessionId ?? "No session yet — refresh the page"}</li>
+			</ul>
+
+			<h2>All Sessions on This Page</h2>
+			<ul>
+				{connectedSessions.length === 0 ? (
+					<li>None yet</li>
+				) : (
+					connectedSessions.map((id) => <li key={id}>{id}</li>)
+				)}
+			</ul>
+		</div>
+	);
+};

--- a/src/components/dev/QrPollClient.tsx
+++ b/src/components/dev/QrPollClient.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useSyncedState } from "rwsdk/use-synced-state/client";
 import { QRCodeSVG } from "qrcode.react";
 import { useEffect } from "react";
+import { useSyncedState } from "rwsdk/use-synced-state/client";
 
 type Props = {
 	sessionId: string | null;

--- a/src/pages/dev/qr-poll.tsx
+++ b/src/pages/dev/qr-poll.tsx
@@ -4,7 +4,10 @@ import { QrPollClient } from "@/components/dev/QrPollClient";
 import { sessions } from "@/session/store";
 import type { AppContext } from "@/worker";
 
-export const QrPoll = async ({ request, response }: RequestInfo<Record<string, never>, AppContext>) => {
+export const QrPoll = async ({
+	request,
+	response,
+}: RequestInfo<Record<string, never>, AppContext>) => {
 	const session = await sessions.load(request);
 
 	if (!session) {

--- a/src/pages/dev/qr-poll.tsx
+++ b/src/pages/dev/qr-poll.tsx
@@ -1,0 +1,34 @@
+import type { RequestInfo } from "rwsdk/worker";
+
+import { QrPollClient } from "@/components/dev/QrPollClient";
+import { sessions } from "@/session/store";
+import type { AppContext } from "@/worker";
+
+export const QrPoll = async ({ request, response }: RequestInfo<Record<string, never>, AppContext>) => {
+	const session = await sessions.load(request);
+
+	if (!session) {
+		await sessions.save(response.headers, { userId: null });
+	}
+
+	const sessionId = getSessionId(request, response.headers);
+	const pollUrl = `${new URL(request.url).origin}/dev/qr-poll`;
+
+	return <QrPollClient sessionId={sessionId} pollUrl={pollUrl} />;
+};
+
+function getSessionId(request: Request, responseHeaders: Headers): string | null {
+	// Existing session: read from request cookie
+	const cookieHeader = request.headers.get("Cookie") ?? "";
+	for (const cookie of cookieHeader.split(";")) {
+		const trimmed = cookie.trim();
+		if (trimmed.startsWith("session_id=")) {
+			return trimmed.slice("session_id=".length);
+		}
+	}
+
+	// New session: read from the Set-Cookie header we just wrote
+	const setCookie = responseHeaders.get("Set-Cookie") ?? "";
+	const match = setCookie.match(/(?:^|,\s*)session_id=([^;,]+)/);
+	return match?.[1] ?? null;
+}

--- a/src/session/store.ts
+++ b/src/session/store.ts
@@ -4,4 +4,5 @@ import { defineDurableSession } from "rwsdk/auth";
 export const sessions = defineDurableSession({
 	// biome-ignore lint/style/noNonNullAssertion: binding always present in Workers runtime
 	sessionDurableObject: env.SESSION_DO!,
+	secretKey: env.SESSION_SECRET_KEY,
 });

--- a/src/worker.tsx
+++ b/src/worker.tsx
@@ -1,9 +1,10 @@
-import { render, route } from "rwsdk/router";
+import { prefix, render, route } from "rwsdk/router";
 import { SyncedStateServer, syncedStateRoutes } from "rwsdk/use-synced-state/worker";
 import { defineApp } from "rwsdk/worker";
 
 import { Document } from "@/document";
 import headerMiddleware from "@/middleware/headers";
+import { QrPoll } from "@/pages/dev/qr-poll";
 import { Home } from "@/pages/home";
 import { SessionDurableObject } from "@/session/durable-object";
 
@@ -18,7 +19,10 @@ export default defineApp([
 	},
 	// biome-ignore lint/style/noNonNullAssertion: binding always present in Workers runtime
 	...syncedStateRoutes((e) => e.SYNCED_STATE_DO!),
-	render(Document, [route("/", Home)]),
+	render(Document, [
+		route("/", Home),
+		...prefix("/dev", [route("/qr-poll", QrPoll)]),
+	]),
 ]);
 
 // Required top-level named exports for wrangler Durable Object bindings

--- a/src/worker.tsx
+++ b/src/worker.tsx
@@ -19,10 +19,7 @@ export default defineApp([
 	},
 	// biome-ignore lint/style/noNonNullAssertion: binding always present in Workers runtime
 	...syncedStateRoutes((e) => e.SYNCED_STATE_DO!),
-	render(Document, [
-		route("/", Home),
-		...prefix("/dev", [route("/qr-poll", QrPoll)]),
-	]),
+	render(Document, [route("/", Home), ...prefix("/dev", [route("/qr-poll", QrPoll)])]),
 ]);
 
 // Required top-level named exports for wrangler Durable Object bindings

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -11,6 +11,7 @@ declare namespace Cloudflare {
 	interface Env {
 		ASSETS?: Fetcher;
 		SESSION_DO?: DurableObjectNamespace<import("./src/worker").SessionDurableObject>;
+		SESSION_SECRET_KEY?: string;
 		SYNCED_STATE_DO?: DurableObjectNamespace<import("./src/worker").SyncedStateServer>;
 	}
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -10,7 +10,10 @@
 	"observability": {
 		"enabled": true
 	},
-	"vars": {},
+	"vars": {
+		// Placeholder for type generation — set the real value via `wrangler secret put SESSION_SECRET_KEY`
+		"SESSION_SECRET_KEY": ""
+	},
 	"durable_objects": {
 		"bindings": [
 			{ "name": "SESSION_DO", "class_name": "SessionDurableObject" },


### PR DESCRIPTION
## Summary
- Adds \`/dev/qr-poll\` route — a dev/testing page for QR code-initiated polls
- Renders a QR code (via \`qrcode.react\`) pointing to itself using the request origin, so it works correctly in integration, staging, and production
- Loads or creates a session on page load; passes the session ID down to the client
- Uses \`useSyncedState\` (room: \`dev-qr-poll\`, key: \`sessions\`) to maintain a shared list of all session IDs that have landed on the page — updates in realtime across all connected clients
- Shows the current user's session ID and the full list of connected session IDs as plain \`<ul>\` lists

## ⚠️ Prerequisite: AUTH_SECRET_KEY secret
Sessions require an \`AUTH_SECRET_KEY\` env var. You'll need to set it as a Wrangler secret for each environment before this page will work in a deployed environment:
\`\`\`
wrangler secret put AUTH_SECRET_KEY --env integration
wrangler secret put AUTH_SECRET_KEY --env staging
wrangler secret put AUTH_SECRET_KEY --env production
\`\`\`
Use a long random string (e.g. \`openssl rand -hex 32\`). Local dev uses a built-in fallback key automatically.

## Test plan
- [ ] Visit \`/dev/qr-poll\` locally — QR code appears, your session ID shows
- [ ] Open a second browser/tab — your session ID appears in the "All Sessions" list on both tabs in realtime
- [ ] Scan the QR code with a phone — phone's session ID appears in the list on all other clients