### PR TITLE
fix: use PAT for semantic-release to trigger deploy workflow on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,5 +36,5 @@ jobs:
 
       - name: Semantic Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: pnpm semantic-release


### PR DESCRIPTION
## Problem
Semantic-release was using `GITHUB_TOKEN` to push the release tag. GitHub intentionally does not trigger workflows from events caused by `GITHUB_TOKEN` (to prevent loops), so the `deploy.yml` `on: push: tags` trigger never fired.

## Fix
Switch semantic-release to use a PAT (`GH_TOKEN`) — tags pushed by a PAT do trigger downstream workflows.

## Required: create a PAT and add it as a secret
1. Go to **GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens**
2. Create a token scoped to this repo with:
   - **Contents: Write** (push tags + commits)
   - **Issues: Write** (semantic-release release notes)
   - **Pull requests: Write** (semantic-release PR comments)
3. Add it as a secret named `GH_TOKEN` in **repo Settings → Secrets and variables → Actions**