### PR TITLE
fix: trigger deploy workflow explicitly from release rather than tag push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,15 @@
 name: Deploy
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to deploy (e.g. v1.2.3)"
+        required: true
+        type: string
 
 concurrency:
-  group: deploy-${{ github.ref_name }}
+  group: deploy-${{ inputs.tag }}
   cancel-in-progress: false
 
 jobs:
@@ -19,6 +22,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
 
       - uses: pnpm/action-setup@v4
         with:
@@ -48,6 +53,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
 
       - uses: pnpm/action-setup@v4
         with:
@@ -77,6 +84,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
 
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,3 +38,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: pnpm semantic-release
+
+      - name: Trigger Deploy
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          TAG=$(git describe --tags --abbrev=0)
+          echo "Triggering deploy for $TAG"
+          gh workflow run deploy.yml --ref main --field tag="$TAG"


### PR DESCRIPTION
## Problem
`on: push: tags: v*` never fires because semantic-release creates the tag via the GitHub API (through `@semantic-release/github`), not via `git push`. No push event = no workflow trigger.

## Fix
- `deploy.yml` now uses `workflow_dispatch` with a required `tag` input, and checks out that tag explicitly in each job
- `release.yml` adds a "Trigger Deploy" step that runs after semantic-release, reads the new tag with `git describe --tags --abbrev=0`, and calls `gh workflow run deploy.yml --field tag="$TAG"`

This makes the trigger explicit and deterministic — no dependency on webhook events.

## Note
`GH_TOKEN` (PAT) is still needed for the `gh workflow run` call. The PAT from the previous fix is reused here.