### PR TITLE
fix: add SESSION_SECRET_KEY var to all wrangler environments

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -26,7 +26,10 @@
 	"env": {
 		"integration": {
 			"name": "golden-key-matrix-integration",
-			"vars": {},
+			"vars": {
+				// Placeholder for type generation — set the real value via `wrangler secret put SESSION_SECRET_KEY`
+				"SESSION_SECRET_KEY": ""
+			},
 			"durable_objects": {
 				"bindings": [
 					{ "name": "SESSION_DO", "class_name": "SessionDurableObject" },
@@ -36,7 +39,10 @@
 		},
 		"staging": {
 			"name": "golden-key-matrix-staging",
-			"vars": {},
+			"vars": {
+				// Placeholder for type generation — set the real value via `wrangler secret put SESSION_SECRET_KEY`
+				"SESSION_SECRET_KEY": ""
+			},
 			"durable_objects": {
 				"bindings": [
 					{ "name": "SESSION_DO", "class_name": "SessionDurableObject" },
@@ -46,7 +52,10 @@
 		},
 		"production": {
 			"name": "golden-key-matrix",
-			"vars": {},
+			"vars": {
+				// Placeholder for type generation — set the real value via `wrangler secret put SESSION_SECRET_KEY`
+				"SESSION_SECRET_KEY": ""
+			},
 			"durable_objects": {
 				"bindings": [
 					{ "name": "SESSION_DO", "class_name": "SessionDurableObject" },


### PR DESCRIPTION
## Summary
- `vars` are not inherited by named environments in wrangler (same issue we hit with `durable_objects`)
- Adds the `SESSION_SECRET_KEY` placeholder to `integration`, `staging`, and `production` env blocks
- Fixes deploy warning: _"vars.SESSION_SECRET_KEY exists at the top level, but not on env.integration"_

## Reminder
Set the actual secret per environment before the session store will work:
\`\`\`
wrangler secret put SESSION_SECRET_KEY --env integration
wrangler secret put SESSION_SECRET_KEY --env staging
wrangler secret put SESSION_SECRET_KEY --env production
\`\`\`