### PR TITLE
fix: remove SESSION_SECRET_KEY empty var that was overriding the secret

### DIFF
--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -11,8 +11,7 @@ declare namespace Cloudflare {
 	interface Env {
 		ASSETS?: Fetcher;
 		SESSION_DO?: DurableObjectNamespace<import("./src/worker").SessionDurableObject>;
-		SESSION_SECRET_KEY?: string;
-		SYNCED_STATE_DO?: DurableObjectNamespace<import("./src/worker").SyncedStateServer>;
+SYNCED_STATE_DO?: DurableObjectNamespace<import("./src/worker").SyncedStateServer>;
 	}
 }
 interface Env extends Cloudflare.Env {}

--- a/worker-secrets.d.ts
+++ b/worker-secrets.d.ts
@@ -1,0 +1,10 @@
+// Secrets are not included in the auto-generated worker-configuration.d.ts.
+// Add types for secrets here so they appear on the Env interface without
+// being wiped out by `pnpm generate` (`wrangler types`).
+//
+// Set values via: wrangler secret put <SECRET> --env <environment>
+declare namespace Cloudflare {
+	interface Env {
+		SESSION_SECRET_KEY?: string;
+	}
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -10,10 +10,7 @@
 	"observability": {
 		"enabled": true
 	},
-	"vars": {
-		// Placeholder for type generation — set the real value via `wrangler secret put SESSION_SECRET_KEY`
-		"SESSION_SECRET_KEY": ""
-	},
+	"vars": {},
 	"durable_objects": {
 		"bindings": [
 			{ "name": "SESSION_DO", "class_name": "SessionDurableObject" },
@@ -26,10 +23,7 @@
 	"env": {
 		"integration": {
 			"name": "golden-key-matrix-integration",
-			"vars": {
-				// Placeholder for type generation — set the real value via `wrangler secret put SESSION_SECRET_KEY`
-				"SESSION_SECRET_KEY": ""
-			},
+			"vars": {},
 			"durable_objects": {
 				"bindings": [
 					{ "name": "SESSION_DO", "class_name": "SessionDurableObject" },
@@ -39,10 +33,7 @@
 		},
 		"staging": {
 			"name": "golden-key-matrix-staging",
-			"vars": {
-				// Placeholder for type generation — set the real value via `wrangler secret put SESSION_SECRET_KEY`
-				"SESSION_SECRET_KEY": ""
-			},
+			"vars": {},
 			"durable_objects": {
 				"bindings": [
 					{ "name": "SESSION_DO", "class_name": "SessionDurableObject" },
@@ -57,10 +48,7 @@
 				{ "pattern": "golden-key-matrix.com", "custom_domain": true },
 				{ "pattern": "www.golden-key-matrix.com", "custom_domain": true }
 			],
-			"vars": {
-				// Placeholder for type generation — set the real value via `wrangler secret put SESSION_SECRET_KEY`
-				"SESSION_SECRET_KEY": ""
-			},
+			"vars": {},
 			"durable_objects": {
 				"bindings": [
 					{ "name": "SESSION_DO", "class_name": "SessionDurableObject" },


### PR DESCRIPTION
## Summary
- Empty-string vars in `wrangler.jsonc` take precedence over Cloudflare secrets with the same name — the session store was receiving `""` instead of the actual secret, causing a startup crash
- Removes `SESSION_SECRET_KEY` from all `vars` blocks so the secret is used as intended
- Adds `worker-secrets.d.ts` to hold secret type declarations separately from the auto-generated `worker-configuration.d.ts` — this file won't be overwritten by `pnpm generate`

## No action needed in Cloudflare
The secret is already set in the integration worker — this just gets out of its way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)